### PR TITLE
show error messages if failed to add user

### DIFF
--- a/lib/mcomaster/add_user_cli.rb
+++ b/lib/mcomaster/add_user_cli.rb
@@ -24,8 +24,14 @@ def run
   end
   puts 'DEFAULT USERS'
   user = User.find_or_create_by_email :name => $user, :email => $email, :password => $password, :password_confirmation => $password
-  puts 'user: ' << user.name
-  user.add_role :admin
+
+  if user.valid?
+    puts 'user: ' << user.name
+    user.add_role :admin
+  else
+    puts "Failed to add user: %s" % user.errors.messages
+    exit 1
+  end
 end
 
 end


### PR DESCRIPTION
When I run `RAILS_ENV=production script/add_user.sh -u test -p test -m 'email@domain.com'` it shows that the user is added. But in fact the password is too short and the `add_user` is failed.  It's a bit confusing.

I think if the operation fails, we should let users know what exactly has happened.
