### PR TITLE
fix compatibility with mcollective > 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'uuidtools'
 gem "thin", ">= 1.5.0"
 gem "redis"
 gem "rake"
-gem "mcollective-client", '~> 2.2.3'
+gem "mcollective-client", '>= 2.4.0'
 gem "rspec-rails", ">= 2.12.2", :group => [:development, :test]
 gem "capybara", ">= 2.0.2", :group => :test
 gem "database_cleaner", ">= 1.0.0.RC1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     jquery-ui-rails (4.0.4)
       jquery-rails
       railties (>= 3.1.0)
-    json (1.8.0)
+    json (1.8.1)
     launchy (2.3.0)
       addressable (~> 2.3)
     libv8 (3.11.8.17)
@@ -94,7 +94,7 @@ GEM
       treetop (~> 1.4.8)
     marionette-rails (1.0.4)
       rails (>= 3.1.0)
-    mcollective-client (2.2.4)
+    mcollective-client (2.5.3)
       json
       stomp
       systemu
@@ -158,8 +158,8 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.7)
-    stomp (1.2.12)
-    systemu (2.5.2)
+    stomp (1.3.2)
+    systemu (2.6.4)
     therubyracer (0.11.4)
       libv8 (~> 3.11.8.12)
       ref
@@ -203,7 +203,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   marionette-rails
-  mcollective-client (~> 2.2.3)
+  mcollective-client (>= 2.4.0)
   momentjs-rails
   protected_attributes
   quiet_assets (>= 1.0.2)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,7 @@ Prerequisites
  * This guide assumes that you already have mcollective working, and it probably helps to be familiar with it.
  * Redis database (a standalone process) is running and accessible. No setup is needed (at least in Fedora and Debian), just install the package and start the service.
  * Bundler (to install dependencies).
+ * Mcollective version must be >= 2.4 .
 
 Setup mcollective
 -----------------


### PR DESCRIPTION
The mcollective > 2.4 have a new method
MCollective::Util.str_to_bool,
if using mcollective-client with gem < 2.4
and using mcollective > 2.4 the discovery
works only for nodes and collectives.

And the agent discovery gives error
undefined method MCollective::Util.str_to_bool.

This change makes mcomaster compatible with
mcollective > 2.4, and drops compatibility with
mcollective < 2.4.

Update dependency list on INSTALL.md

We require that user have mcollective > 2.4
