### PR TITLE
fix initscript to correctly support thin.

### DIFF
--- a/extra/rpms/el-6/SOURCES/mcomaster.init
+++ b/extra/rpms/el-6/SOURCES/mcomaster.init
@@ -27,7 +27,7 @@ if [[ -z $MCOMASTER_PID ]]
 then
     if [[ $MCOMASTER_USE_THIN = 1 ]]
     then
-        MCOMASTER_PID=${MCOMASTER_HOME}/tmp/pids/thin.*.pid
+        MCOMASTER_PID=${MCOMASTER_HOME}/tmp/pids/thin.pid
     else
         MCOMASTER_PID=${MCOMASTER_HOME}/tmp/pids/server.pid
     fi
@@ -48,11 +48,15 @@ start() {
           /usr/bin/ruby193-ruby ${MCOMASTER_HOME}/bin/thin start --user ${MCOMASTER_USER} \
             --environment $MCOMASTER_ENV \
             --group ${MCOMASTER_USER} \
+            --port ${MCOMASTER_PORT}  \
+            --pid ${MCOMASTER_PID}  \
             --rackup "${MCOMASTER_HOME}/config.ru" -d --ssl
         else
           /usr/bin/ruby193-ruby ${MCOMASTER_HOME}/bin/thin start --user ${MCOMASTER_USER} \
             --environment $MCOMASTER_ENV \
             --group ${MCOMASTER_USER} \
+            --port ${MCOMASTER_PORT}  \
+            --pid ${MCOMASTER_PID}  \
             --rackup "${MCOMASTER_HOME}/config.ru" -d
         fi
     else


### PR DESCRIPTION
The mcomaster status was not working if using thin.
This was happening because if called without pid argument,
thin was creating the pid file on /tmp/pids/thin.pid,
and the initscript expected it on MCOMASTER_HOME/tmp/pids/thin.*.pid.

Also the ports defined on /etc/sysconfig/mcomaster was not being respected
if using thin. It was missing the --port parameter for thin to listen on
MCOMASTER_PORT.

This commit fix thin port support and the thin pid location.
