### PR TITLE
fix vagrant activemq install and mcollective version

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -15,6 +15,7 @@ mod 'puppetlabs/firewall', '1.1.3'
 mod 'thomasvandoren/redis', '0.10.0'
 mod 'maestrodev/wget', '1.4.4'
 mod 'puppetlabs/gcc', '0.2.0'
+mod 'puppetlabs/java', '1.1.2'
 # A module from the Puppet Forge
 # mod 'puppetlabs/stdlib'
 

--- a/tools/vagrant/deploy/site.pp
+++ b/tools/vagrant/deploy/site.pp
@@ -64,8 +64,16 @@ node /middleware/ {
   #config mcollective
   class { '::mcollective':
     middleware       => true,
+    version           => '2.6.1-1.el6',
     middleware_hosts => [ 'middleware' ],
-    require => Class['custom_firewall::pre'],
+   require => [Class['custom_firewall::pre'], Package['tanukiwrapper'], Class['java']],
+  }
+  class  { 'java':
+    distribution => 'jdk',
+    version      => 'latest',
+  }
+  package {'tanukiwrapper':
+    ensure => present
   }
   class {'::mcomaster::config::mcollective::server': 
     redis_host => "middleware"
@@ -90,7 +98,7 @@ node /mcomaster/ {
     client            => true,
     middleware_hosts  => [ 'middleware' ],
     require           => Class['custom_firewall::pre'],
-    version           => '2.5.3-1.el6',
+    version           => '2.6.1-1.el6',
   }
   class {'::mcomaster::config::mcollective::server': 
     redis_host => "middleware"
@@ -120,6 +128,7 @@ node /mcserver/ {
   }
   #Call custom class
   class { '::mcollective':
+    version           => '2.6.1-1.el6',
     middleware_hosts => [ 'middleware' ],
     require          => Class['custom_firewall::pre'],
   }


### PR DESCRIPTION
The new version of activemq rpm package 5.9 does not require
the tanukiwrapper rpm, because it provides a new init script.

But the puppetlabs-activemq module, install one old init script
that require tanukiwrapper, this means that the activemq installation
is broken.

Also it was tanukiwrapper that required the java package, without it
the system is with activemq installed and without java, so it does not
work.

The puppetlabs-activemq must be patched upstream, until this happens
we are manually ensuring java and tanukiwrapper is installed.

this commit also updates the version of mcollective to support the
mcollective-client gem that is used by the rpm.

it is important to always update the mcollective package version after
changing the Gemfile mcollective version.
