### PR TITLE
fix json api calls csrf validation (Can't verify CSRF token authenticity)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format.json? }
 
   rescue_from CanCan::AccessDenied do |exception|
     #redirect_to root_path, :alert => exception.message


### PR DESCRIPTION
The policies controller was having problem with csrf validation
after logging out and login in on the application.

It was unable to add the default policy and agent policies.
## the log on the server logs was :

Started POST "/policies" for 10.0.2.2 at 2014-10-31 01:28:47 +0000
Processing by PoliciesController#create as JSON
  Parameters: {"policy"=>"allow", "agent"=>"nrpe", "action_name"=>"_", "callerid"=>"vagrant"}
Can't verify CSRF token authenticity
  User Load (0.5ms)  SELECT  "users"._ FROM "users"  WHERE "users"."id" = 1  ORDER BY "users"."id" ASC LIMIT 1
   (0.1ms)  begin transaction
   (0.1ms)  commit transaction
## Completed 401 Unauthorized in 64ms

This commit fixes this problem.
This change instead of completely turning off the built in security, kills off any session that might exist when something hits the server without the CSRF token.

more information can be found on :
https://coderwall.com/p/8z7z3a
